### PR TITLE
Inline `<style>` and `<link>` support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,7 @@ dmypy.json
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# PDM package manager
+.pdm-python
+pdm.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["html", "css", "image", "conversion", "rendering"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -33,6 +33,7 @@ dependencies = [
     "pictex>=2.0.0",
     "beautifulsoup4>=4.9.0",
     "tinycss2>=1.1.0",
+    "requests>=2.32.5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,7 @@ classifiers = [
 dependencies = [
     "pictex>=2.0.0",
     "beautifulsoup4>=4.9.0",
-    "tinycss2>=1.1.0",
-    "requests>=2.32.5",
+    "tinycss2>=1.1.0"
 ]
 
 [project.optional-dependencies]

--- a/src/html2pic/html2pic.py
+++ b/src/html2pic/html2pic.py
@@ -11,7 +11,14 @@ from .exceptions import RenderError
 from .dom import DOMNode
 from .parsing import CSSRule
 from .fonts import FontRegistry
-from typing import Optional, List
+from typing import Optional, List, Callable
+
+def default_fetcher(url: str) -> str:
+    """Default fetcher function to retrieve content from a URL."""
+    import requests
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.text
 
 class Html2Pic:
     """Convert HTML + CSS to images using PicTex.
@@ -27,9 +34,14 @@ class Html2Pic:
         ```
     """
     
-    def __init__(self, html: str, css: str = ""):
+    def __init__(self, html: str, css: str = "", fetcher: Optional[Callable[[str], str]] = None, root_url: Optional[str] = None):
         self.html = html
         self.css = css
+        if fetcher is None:
+            self.fetcher = default_fetcher
+        else:
+            self.fetcher = fetcher
+        self.root_url = root_url
         
         self._html_parser: HtmlParser = HtmlParser()
         self._css_parser: CssParser = CssParser()
@@ -48,11 +60,18 @@ class Html2Pic:
     def dom_tree(self) -> DOMNode:
         if self._dom_tree is None:
             self._dom_tree = self._html_parser.parse(self.html)
+            # Extract CSS from DOM and append to self.css
+            extracted_css = self._extract_css_from_dom(self._dom_tree)
+            if extracted_css:
+                self.css = self.css + "\n\n" + extracted_css if self.css else extracted_css
         return self._dom_tree
     
     @property
     def style_rules(self) -> List[CSSRule]:
         if self._style_rules is None:
+            # Ensure DOM is parsed first (which extracts CSS)
+            _ = self.dom_tree
+            # Now parse all CSS including extracted content
             self._style_rules, self._font_registry = self._css_parser.parse(self.css)
         return self._style_rules
 
@@ -60,7 +79,7 @@ class Html2Pic:
     def font_registry(self) -> FontRegistry:
         if self._font_registry is None:
             _ = self.style_rules
-        return self._font_registry
+        return self._font_registry # pyright: ignore[reportReturnType]
     
     @property
     def styled_tree(self) -> DOMNode:
@@ -103,6 +122,45 @@ class Html2Pic:
         except Exception as e:
             self._print_warnings()
             raise RenderError(f"Failed to render SVG: {e}") from e
+    
+    def _extract_css_from_dom(self, node: DOMNode) -> str:
+        """Extract CSS from <style> tags and <link> tags."""
+        css_content = []
+        
+        def traverse(n: DOMNode):
+            if n.is_element():
+                # Extract <style> tag content
+                if n.tag and n.tag.lower() == 'style':
+                    text = n.get_all_text().strip()
+                    if text:
+                        css_content.append(text)
+                
+                # Extract <link rel="stylesheet"> tags
+                elif n.tag and n.tag.lower() == 'link':
+                    rel = n.attributes.get('rel', '').lower()
+                    if rel == 'stylesheet':
+                        href = n.attributes.get('href')
+                        if href:
+                            try:
+                                # Resolve URL if root_url is provided
+                                if self.root_url and not href.startswith(('http://', 'https://')):
+                                    from urllib.parse import urljoin
+                                    href = urljoin(self.root_url, href)
+                                
+                                # Fetch CSS content
+                                # FIXME: Workaround; CSS3 @import handling is not implemented here
+                                fetched_css = self.fetcher(href)
+                                if fetched_css:
+                                    css_content.append(fetched_css)
+                            except Exception as e:
+                                self._warnings.warn_unexpected_error(f"Failed to fetch CSS from {href}: {e}")
+                
+                # Traverse children
+                for child in n.children:
+                    traverse(child)
+        
+        traverse(node)
+        return '\n\n'.join(css_content)
     
     def debug_info(self) -> Dict[str, Any]:
         return {

--- a/src/html2pic/html2pic.py
+++ b/src/html2pic/html2pic.py
@@ -13,13 +13,6 @@ from .parsing import CSSRule
 from .fonts import FontRegistry
 from typing import Optional, List, Callable
 
-def default_fetcher(url: str) -> str:
-    """Default fetcher function to retrieve content from a URL."""
-    import requests
-    response = requests.get(url, timeout=30)
-    response.raise_for_status()
-    return response.text
-
 class Html2Pic:
     """Convert HTML + CSS to images using PicTex.
     
@@ -37,10 +30,7 @@ class Html2Pic:
     def __init__(self, html: str, css: str = "", fetcher: Optional[Callable[[str], str]] = None, root_url: Optional[str] = None):
         self.html = html
         self.css = css
-        if fetcher is None:
-            self.fetcher = default_fetcher
-        else:
-            self.fetcher = fetcher
+        self.fetcher = fetcher
         self.root_url = root_url
         
         self._html_parser: HtmlParser = HtmlParser()
@@ -139,6 +129,9 @@ class Html2Pic:
                 elif n.tag and n.tag.lower() == 'link':
                     rel = n.attributes.get('rel', '').lower()
                     if rel == 'stylesheet':
+                        if not self.fetcher:
+                            self._warnings.warn_unexpected_error("No fetcher provided.")
+                            return
                         href = n.attributes.get('href')
                         if href:
                             try:

--- a/src/html2pic/parsing/css_parser.py
+++ b/src/html2pic/parsing/css_parser.py
@@ -9,7 +9,7 @@ from .shorthand_expander import ShorthandExpander
 from ..fonts import FontFace, FontRegistry, FontSrcParser
 from ..warnings import get_warning_collector
 from ..exceptions import ParseError
-from ..styiling import DEFAULT_STYLES
+from ..styling import DEFAULT_STYLES
 
 
 class CssParser:

--- a/src/html2pic/parsing/html_parser.py
+++ b/src/html2pic/parsing/html_parser.py
@@ -1,7 +1,9 @@
 """HTML parser using BeautifulSoup."""
+
 from typing import Optional
 
-from bs4 import BeautifulSoup, NavigableString, Tag
+from bs4 import BeautifulSoup, Tag
+from bs4.element import NavigableString
 
 from ..dom import DOMNode, NodeType
 from ..warnings import get_warning_collector
@@ -10,67 +12,67 @@ from ..exceptions import ParseError
 
 class HtmlParser:
     """Parses HTML content into a DOM tree."""
-    
-    SKIP_TAGS = {'script', 'style', 'head', 'meta', 'link', 'title'}
-    
+
+    SKIP_TAGS = {"script", "meta", "title"}
+
     def __init__(self):
         self.warnings = get_warning_collector()
-    
+
     def parse(self, html_content: str) -> DOMNode:
         """Parse HTML string into a DOM tree."""
         try:
-            soup = BeautifulSoup(html_content, 'html.parser')
+            soup = BeautifulSoup(html_content, "html.parser")
             return self._create_root(soup)
         except Exception as e:
             raise ParseError(f"Failed to parse HTML: {e}") from e
-    
+
     def _create_root(self, soup: BeautifulSoup) -> DOMNode:
-        root = DOMNode(node_type=NodeType.ELEMENT, tag='div', attributes={'class': '_root'})
-        
+        root = DOMNode(
+            node_type=NodeType.ELEMENT, tag="div", attributes={"class": "_root"}
+        )
+
         for child in soup.children:
             child_node = self._process_node(child, root)
             if child_node:
                 root.children.append(child_node)
-        
+
         return root
-    
+
     def _process_node(self, node, parent: DOMNode) -> Optional[DOMNode]:
         if isinstance(node, NavigableString):
             text = str(node).strip()
             if text:
                 return DOMNode(
-                    node_type=NodeType.TEXT,
-                    text_content=text,
-                    parent=parent
+                    node_type=NodeType.TEXT, text_content=text, parent=parent
                 )
             return None
-        
+
         if isinstance(node, Tag):
             tag_name = node.name.lower()
-            
+
             if tag_name in self.SKIP_TAGS:
                 self.warnings.warn_unsupported_html_tag(tag_name)
                 return None
-            
+
             attrs = {}
             for key, value in node.attrs.items():
                 if isinstance(value, list):
-                    attrs[key] = ' '.join(value)
+                    attrs[key] = " ".join(value)
                 else:
                     attrs[key] = value
-            
+
             dom_node = DOMNode(
                 node_type=NodeType.ELEMENT,
                 tag=tag_name,
                 attributes=attrs,
-                parent=parent
+                parent=parent,
             )
-            
+
             for child in node.children:
                 child_node = self._process_node(child, dom_node)
                 if child_node:
                     dom_node.children.append(child_node)
-            
+
             return dom_node
-        
+
         return None

--- a/src/html2pic/translation/translator.py
+++ b/src/html2pic/translation/translator.py
@@ -25,6 +25,8 @@ from .style_applicators import (
 class PicTexTranslator:
     """Translates a styled DOM tree into PicTex builders."""
     
+    SKIP_TAGS = {"link", "style", "head"}
+    
     def __init__(self):
         self.warnings = get_warning_collector()
         self.element_factory = ElementFactory()
@@ -35,7 +37,7 @@ class PicTexTranslator:
     def translate(
         self, 
         styled_dom: DOMNode, 
-        font_registry: FontRegistry = None
+        font_registry: Optional[FontRegistry] = None
     ) -> Tuple[Canvas, Optional[Element]]:
         """Translate a styled DOM tree to PicTex builders."""
         self.font_registry = font_registry
@@ -73,6 +75,9 @@ class PicTexTranslator:
         return self.element_factory.create_text(content)
     
     def _create_element(self, node: DOMNode) -> Optional[Element]:
+        if node.tag and node.tag.lower() in self.SKIP_TAGS:
+            return None
+        
         styles = node.computed_styles
         
         if styles.get('display') == 'none':


### PR DESCRIPTION
Implements #1.

# Caveat

- When using `<link>`, CSS3 `@import` syntax is not supported (there's also problems on URL handling). However it is unable to fix the caveat without making REALLY huge changes, so I will just leave it. Maybe you should add a todo for it.

# Relevant possibly incompatible changes

My package manager is unable to resolve all the dependencies under Python version `>=3.8`. I bumped it to `>=3.9` for fix. This may result in incompatibility.

Detailed output (pdm):

```
❯ pdm install
WARNING: Lockfile does not exist
Updating the lock file...
INFO: Virtualenv /home/(redacted)/html2pic/.venv is reused.
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping pictex@2.0.1 because it requires
Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of pictex that supports Python>=3.8
will be used.
If you want to install pictex@2.0.1, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping pictex@2.0.0 because it requires
Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of pictex that supports Python>=3.8
will be used.
If you want to install pictex@2.0.0, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping tinycss2@1.5.1 because it
requires Python>=3.10 but the lock targets to work with Python>=3.8. Instead, another version of tinycss2 that supports
Python>=3.8 will be used.
If you want to install tinycss2@1.5.1, narrow down the `requires-python` range to include this version. For example,
">=3.10" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping tinycss2@1.5.0 because it
requires Python>=3.10 but the lock targets to work with Python>=3.8. Instead, another version of tinycss2 that supports
Python>=3.8 will be used.
If you want to install tinycss2@1.5.0, narrow down the `requires-python` range to include this version. For example,
">=3.10" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping soupsieve@2.8.2 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of soupsieve that supports
Python>=3.8 will be used.
If you want to install soupsieve@2.8.2, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping soupsieve@2.8.1 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of soupsieve that supports
Python>=3.8 will be used.
If you want to install soupsieve@2.8.1, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping soupsieve@2.8 because it requires
Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of soupsieve that supports
Python>=3.8 will be used.
If you want to install soupsieve@2.8, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping typing-extensions@4.15.0 because
it requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of typing-extensions
that supports Python>=3.8 will be used.
If you want to install typing-extensions@4.15.0, narrow down the `requires-python` range to include this version. For
example, ">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping typing-extensions@4.14.1 because
it requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of typing-extensions
that supports Python>=3.8 will be used.
If you want to install typing-extensions@4.14.1, narrow down the `requires-python` range to include this version. For
example, ">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping typing-extensions@4.14.0 because
it requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of typing-extensions
that supports Python>=3.8 will be used.
If you want to install typing-extensions@4.14.0, narrow down the `requires-python` range to include this version. For
example, ">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping importlib-resources@6.5.2 because
it requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of importlib-resources
that supports Python>=3.8 will be used.
If you want to install importlib-resources@6.5.2, narrow down the `requires-python` range to include this version. For
example, ">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping importlib-resources@6.5.1 because
it requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of importlib-resources
that supports Python>=3.8 will be used.
If you want to install importlib-resources@6.5.1, narrow down the `requires-python` range to include this version. For
example, ">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping importlib-resources@6.5.0 because
it requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of importlib-resources
that supports Python>=3.8 will be used.
If you want to install importlib-resources@6.5.0, narrow down the `requires-python` range to include this version. For
example, ">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping regex@2026.1.15 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of regex that supports
Python>=3.8 will be used.
If you want to install regex@2026.1.15, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping regex@2026.1.14 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of regex that supports
Python>=3.8 will be used.
If you want to install regex@2026.1.14, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping regex@2025.11.3 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of regex that supports
Python>=3.8 will be used.
If you want to install regex@2025.11.3, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping regex@2025.10.23 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of regex that supports
Python>=3.8 will be used.
If you want to install regex@2025.10.23, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping regex@2025.10.22 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of regex that supports
Python>=3.8 will be used.
If you want to install regex@2025.10.22, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping regex@2025.9.18 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of regex that supports
Python>=3.8 will be used.
If you want to install regex@2025.9.18, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping regex@2025.9.1 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of regex that supports
Python>=3.8 will be used.
If you want to install regex@2025.9.1, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping regex@2025.8.29 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of regex that supports
Python>=3.8 will be used.
If you want to install regex@2025.8.29, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping regex@2025.7.34 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of regex that supports
Python>=3.8 will be used.
If you want to install regex@2025.7.34, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping regex@2025.7.33 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of regex that supports
Python>=3.8 will be used.
If you want to install regex@2025.7.33, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping regex@2025.7.31 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of regex that supports
Python>=3.8 will be used.
If you want to install regex@2025.7.31, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
/usr/lib/python3/dist-packages/pdm/resolver/providers.py:191: PackageWarning: Skipping regex@2025.7.29 because it
requires Python>=3.9 but the lock targets to work with Python>=3.8. Instead, another version of regex that supports
Python>=3.8 will be used.
If you want to install regex@2025.7.29, narrow down the `requires-python` range to include this version. For example,
">=3.9" should work.
  return self.repository.find_candidates(
  0:00:25 🔒 Lock failed.  ERROR: Unable to find a resolution because the following dependencies don't work on all Python versions in the range of
the project's `requires-python`: >=3.8.
  python>=3.9 (from <Candidate pictex@2.0.0 from https://pypi.org/simple/pictex/>)
  python>=3.9 (from <Candidate pictex@2.0.1 from https://pypi.org/simple/pictex/>)
A possible solution is to change the value of `requires-python` in pyproject.toml to >=3.9.
  0:00:25 🔒 Lock failed.
See /home/(redacted)/.local/state/pdm/log/pdm-lock-76c5lwha.log for detailed debug log.
[ResolutionImpossible]: Unable to find a resolution
WARNING: Add '-v' to see the detailed traceback
```

`.gitignore` is changed slightly to work with PDM. This should work fine with previous versions.