### PR TITLE
fix: correct typo in import statement (styiling -> styling)

### DIFF
--- a/src/html2pic/parsing/css_parser.py
+++ b/src/html2pic/parsing/css_parser.py
@@ -9,7 +9,7 @@ from .shorthand_expander import ShorthandExpander
 from ..fonts import FontFace, FontRegistry, FontSrcParser
 from ..warnings import get_warning_collector
 from ..exceptions import ParseError
-from ..styiling import DEFAULT_STYLES
+from ..styling import DEFAULT_STYLES
 
 
 class CssParser:


### PR DESCRIPTION
## Problem
The import statement in `src/html2pic/parsing/css_parser.py` has a typo:
- `from ..styiling import DEFAULT_STYLES` (incorrect)
- Should be `from ..styling import DEFAULT_STYLES`

This causes `ModuleNotFoundError: No module named 'html2pic.styiling'` when importing html2pic.

## Solution
Fixed the typo: `styiling` -> `styling`